### PR TITLE
fixed assignment to undeclared variable attr

### DIFF
--- a/src/component-registry.js
+++ b/src/component-registry.js
@@ -72,7 +72,7 @@ export class ComponentRegistry {
         behavior.processAttributes(compiler, viewResources, this, attributes, behaviorInstruction);
 
         for (let i = 0, ii = attributes.length; i < ii; ++i) {
-          attr = attributes[i];
+          let attr = attributes[i];
           behaviorInstruction.attributes[attr.name] = attr.value;
         }
 


### PR DESCRIPTION
I ran into this when registering a custom element as web component.