### PR TITLE
feat(ce): ability to extend built-in elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,46 @@ export function configure(aurelia) {
 
 > Note: This plugin requires that your browser have native support for the CustomElements v1 spec or that you have configured a v1 spec-compliant polyfill prior to calling registry methods.
 
-### Usage with webpack
+### Extending Built-In Elements
+
+One nice feature of web-components custom elements is that you can extend built-in html elements, such as: button, input etc... and enable the following usage:
+
+```html
+<button is=my-custom-button>...</button>
+```
+
+To extends built-in html element, add `extends` to your view model class, with the value of built-in element that you would like to extend, an example:
+
+```js
+  class MyButton {
+
+    static extends = 'button';
+    static $view = '<template>my button ${icon}</template>';
+
+    @bindable icon;
+  }
+
+  await registry.register(MyButton2);
+```
+And then, you can do
+
+```js
+element.innerHTML = '<button is=my-button icon=♥></button>'
+```
+
+It will render something like this:
+```html
+<button is=my-button icon=♥>my button ♥</button>
+```
+
+`button` is not the only thing you can extend, imagine textarea, paragraph, div and more.
+
+### Usage With Webpack
 
 Web components require the es6/es2015 constructor call type to be used rather than es5 or earlier function prototype-based calls.
 In order to use this plugin with webpack, ensure the `dist` configuration of the `AureliaPlugin` is set to `es2015` or later in `webpack.config.js`
-```
+
+```js
 module.exports = ({...} = {}) => ({
   ...
   plugins: [

--- a/src/custom-element-registry.ts
+++ b/src/custom-element-registry.ts
@@ -3,7 +3,7 @@ import { HtmlBehaviorResource, ViewCompiler, ViewResources, ViewFactory } from '
 import { createWebComponentClassFromBehavior } from './custom-element-utilities';
 import './interface';
 import { ICustomElementInfo, ICustomHtmlRegistry } from './interface';
-import { tagNameOf } from './utilities';
+import { tagNameOf, hyphenate } from './utilities';
 import { metadata } from 'aurelia-metadata';
 
 export class CustomElementRegistry implements ICustomHtmlRegistry {
@@ -71,7 +71,12 @@ export class CustomElementRegistry implements ICustomHtmlRegistry {
       tagName = this.fallbackPrefix + tagName;
     }
 
-    customElements.define(tagName, classDefinition);
+    const args: [string, Function, ElementDefinitionOptions?] = [tagName, classDefinition];
+    const extensionBase = classDefinition.$extends;
+    if (extensionBase) {
+      args.push({ extends: extensionBase });
+    }
+    customElements.define(...args);
 
     return info;
   }
@@ -81,13 +86,21 @@ export class CustomElementRegistry implements ICustomHtmlRegistry {
     // validating metadata
     if (htmlBehaviorResource) {
       ViewResources.convention(Type, htmlBehaviorResource);
-    } else {
+    }
+    else {
       htmlBehaviorResource = ViewResources.convention(Type) as HtmlBehaviorResource;
     }
-    if (!(htmlBehaviorResource instanceof HtmlBehaviorResource) || htmlBehaviorResource.elementName === null) {
+
+    // after running static convetion and there's nothing applied
+    // check if it's a valid html behavior resource
+    if (!(htmlBehaviorResource instanceof HtmlBehaviorResource) || htmlBehaviorResource.attributeName !== null) {
       throw new Error(`class ${Type.name} is already associated with a different type of resource. Cannot register as a custom element.`);
     }
+    else {
+      htmlBehaviorResource.elementName = htmlBehaviorResource.elementName || hyphenate(Type.name);
+    }
 
+    htmlBehaviorResource.target = Type;
     const customElementInfo = this.registerBehavior(htmlBehaviorResource, Type['is']);
     return htmlBehaviorResource
       .load(this.container, Type)

--- a/src/custom-element-utilities.ts
+++ b/src/custom-element-utilities.ts
@@ -41,8 +41,17 @@ export const createWebComponentClassFromBehavior = (
   viewResources: ViewResources,
   compiler: ViewCompiler
 ) => {
+  const CustomElementViewModelClass = behavior.target;
+  const extensionBase = CustomElementViewModelClass.extends;
+  let BaseClass = HTMLElement;
 
-  const CustomElementClass = class extends HTMLElement {
+  if (extensionBase && typeof extensionBase === 'string') {
+    BaseClass = document.createElement(extensionBase).constructor as { new(): any };
+  }
+
+  const CustomElementClass = class extends BaseClass {
+
+    static $extends: string;
 
     /**@internal */
     _children: View[];
@@ -130,9 +139,12 @@ export const createWebComponentClassFromBehavior = (
     }
   };
 
-  const CustomElementViewModelClass = behavior.target;
   const proto = CustomElementClass.prototype;
   const observedAttributes: string[] = [];
+
+  if (typeof extensionBase === 'string' && extensionBase) {
+    CustomElementClass.$extends = extensionBase;
+  }
 
   behavior.properties.forEach(bindableProperty => {
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -58,7 +58,7 @@ declare module 'aurelia-templating' {
     ): void;
     properties: BindableProperty[];
     attributes: Record<string, BindableProperty>;
-    target: Function;
+    target: Function & { extends?: string };
 
     _ensurePropertiesDefined(instance: object, lookup: Record<string, any>): void;
   }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -17,3 +17,18 @@ export const definePrototypeGetterSetter = <T extends object = object>(obj: T, p
   sharedPropertyDescriptor.get = sharedPropertyDescriptor.set = undefined;
   return obj;
 };
+
+const hyphenateCache = {};
+const capitalMatcher = /([A-Z])/g;
+
+const addHyphenAndLower = (char: string): string => {
+  return '-' + char.toLowerCase();
+};
+
+export const hyphenate = (name: string): string => {
+  const result = hyphenateCache[name];
+  if (result !== undefined) {
+    return result;
+  }
+  return hyphenateCache[name] = (name.charAt(0).toLowerCase() + name.slice(1)).replace(capitalMatcher, addHyphenAndLower);
+};

--- a/test/ce.extends-built-in.integration.spec.ts
+++ b/test/ce.extends-built-in.integration.spec.ts
@@ -1,0 +1,51 @@
+import './setup';
+import { bootstrapAurelia } from './utilities-bootstrap';
+import { waitForTimeout } from './utilities-timing';
+import { bindable, customElement } from 'aurelia-framework';
+
+describe('ce.extend-built-in.integration.spec.ts', () => {
+
+  it('should [[NOT]] work in normal usage', async () => {
+    const { host, registry, dispose } = await bootstrapAurelia({
+      root: class RootViewModel {
+        static $view = '<template>';
+      }
+    });
+
+    class MyButton1 {
+
+      static extends = 'button';
+      static $view = '<template>One</template>';
+
+      @bindable icon;
+    }
+
+    await registry.register(MyButton1);
+    host.innerHTML = '<my-button1>';
+    await waitForTimeout(50);
+    expect(host.textContent).toBe('');
+    return dispose();
+  });
+
+  it('should work with "is" attribute', async () => {
+    const { host, registry, dispose } = await bootstrapAurelia({
+      root: class RootViewModel {
+        static $view = '<template>';
+      }
+    });
+
+    class MyButton2 {
+
+      static extends = 'button';
+      static $view = '<template>One';
+
+      @bindable icon;
+    }
+
+    await registry.register(MyButton2);
+    host.innerHTML = '<button is=my-button2>';
+    await waitForTimeout(50);
+    expect(host.textContent).toBe('One');
+    return dispose();
+  });
+});


### PR DESCRIPTION
cc @EisenbergEffect @peitschie

Ability to have the following work:

```html
<button is=my-button2>
```
with declaration:
```ts
class MyButton2 {

      static extends = 'button';
      static $view = '<template>One';

      @bindable icon;
    }
```

@peitschie Can you try this out 😃 